### PR TITLE
Fixed 2019.11.26 update of dnspod

### DIFF
--- a/ddnspod.sh
+++ b/ddnspod.sh
@@ -50,11 +50,11 @@ arDdnsInfo() {
 
     # Get domain ID
     domainID=$(arApiPost "Domain.Info" "domain=$1")
-    domainID=$(echo $domainID | sed 's/.*{"id":"\([0-9]*\)".*/\1/')
+    domainID=$(echo $domainID | sed 's/.*"id":"\([0-9]*\)".*/\1/')
 
     # Get Record ID
     recordID=$(arApiPost "Record.List" "domain_id=$domainID&sub_domain=$2")
-    recordID=$(echo $recordID | sed 's/.*\[{"id":"\([0-9]*\)".*/\1/')
+    recordID=$(echo $recordID | sed 's/.*"id":"\([0-9]*\)".*/\1/')
 
     # Last IP
     recordIP=$(arApiPost "Record.Info" "domain_id=$domainID&record_id=$recordID")


### PR DESCRIPTION
2019.11.26 dnspod更新了返回字段 原先解析已无效，脚本无法正常使用，故更新，经测试正常使用