### PR TITLE
修改中文字符为对应的UrlEncode

### DIFF
--- a/ardnspod
+++ b/ardnspod
@@ -127,7 +127,7 @@ arDdnsUpdate() {
     recordId=$(echo $recordId | sed 's/.*"id":"\([0-9]*\)".*/\1/')
 
     # Update IP
-    recordRs=$(arDdnsApi "Record.Ddns" "domain_id=$domainId&record_id=$recordId&sub_domain=$2&record_type=A&value=$hostIp&record_line=默认")
+    recordRs=$(arDdnsApi "Record.Ddns" "domain_id=$domainId&record_id=$recordId&sub_domain=$2&record_type=A&value=$hostIp&record_line=%e9%bb%98%e8%ae%a4")
     recordIp=$(echo $recordRs | sed 's/.*,"value":"\([0-9\.]*\)".*/\1/')
     recordCd=$(echo $recordRs | sed 's/.*{"code":"\([0-9]*\)".*/\1/')
 


### PR DESCRIPTION
record_line 记录线路，通过API记录线路获得，中文，比如：默认，必选
url中文可能存在问题，建议使用UrlEncode编码。