### PR TITLE
修复@子域名获取NS记录非A记录 fix get subdomain @ IP err

### DIFF
--- a/ardnspod
+++ b/ardnspod
@@ -84,7 +84,7 @@ arDdnsInfo() {
     domainId=$(echo $domainId | sed 's/.*"id":"\([0-9]*\)".*/\1/')
 
     # Get Record ID
-    recordId=$(arDdnsApi "Record.List" "domain_id=$domainId&sub_domain=$2")
+    recordId=$(arDdnsApi "Record.List" "domain_id=$domainId&sub_domain=$2&record_type=A")
     recordId=$(echo $recordId | sed 's/.*"id":"\([0-9]*\)".*/\1/')
 
     # Last IP


### PR DESCRIPTION
修复获取@子域名IP时错误获取NS记录而非A记录
fix get the wrong recordID