### PR TITLE
return 0 when Last IP same as current, instead of return 1

### DIFF
--- a/ardnspod
+++ b/ardnspod
@@ -236,7 +236,7 @@ arDdnsCheck() {
             fi
         fi
         echo "Last IP is the same as current IP!"
-        return 1
+        return 0
     fi
 
     echo "$lastIP"


### PR DESCRIPTION
**Issue about this PR**: https://github.com/anrip/dnspod-shell/issues/63
**Brief summary**: When we execute this script periodically, "Last IP is the same as current IP!" is quite a normal thing, and the result is just as our wish. So we can just `return 0` instead of `return 1` to send an error.